### PR TITLE
Allow additional tags to be passed to dogstatsd via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The following environment variables can be used to configure Raingutter:
 * `RG_STATSD_HOST`: IP address of the local dogstatsd instance (required if `RG_STATSD_ENABLED` is `true`)
 * `RG_STATSD_PORT`: Port number of the local dogstatsd instance (required if `RG_STATSD_ENABLED` is `true`)
 * `RG_STATSD_NAMESPACE`: A string to prepend to all statsd calls (default: `unicorn.raingutter.agg.`)
+* `RG_STATSD_EXTRA_TAGS`: A list of extra tags to be passed to dogstatsd, as comma-separated key:value pairs (ie. `tagname:tagvalue,anothertag:anothervalue`)
 
 ##### PROMETHEUS
 * `RG_PROMETHEUS_ENABLED`: If set to `true` metrics are exposed to `<IP>:8000/metrics` (default: `false`)

--- a/raingutter/raingutter.go
+++ b/raingutter/raingutter.go
@@ -286,6 +286,8 @@ func main() {
 	}
 	log.Info("RG_STATSD_NAMESPACE: ", statsdNamespace)
 
+	statsdExtraTags := os.Getenv("RG_STATSD_EXTRA_TAGS")
+
 	unicorn := os.Getenv("RG_UNICORN")
 	if unicorn == "" {
 		log.Warning("RG_UNICORN is not defined. Set to true by default")
@@ -358,6 +360,12 @@ func main() {
 	if project != "" {
 		tag := "project:" + project
 		statsdClient.Tags = append(statsdClient.Tags, tag)
+	}
+
+	// Add extra tags
+	if statsdExtraTags != "" {
+		tags := strings.Split(statsdExtraTags, ",")
+		statsdClient.Tags = append(statsdClient.Tags, tags...)
 	}
 
 	// Setup os signals catching


### PR DESCRIPTION
### Description
This PR adds support for defining custom tags to be sent to dogstatsd, via a new environment variable, `RG_STATSD_EXTRA_TAGS`. This variable will be read as a comma-separated list of key:value pairs, ie `tagname:tagvalue,anothertag:anothervalue`, each of which will be included with each call.

### CC
@zendesk/guide-ops
