### PR TITLE
Update the signals log level to Info

### DIFF
--- a/raingutter/raingutter.go
+++ b/raingutter/raingutter.go
@@ -362,7 +362,8 @@ func main() {
 	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		s := <-sigs
-		log.Fatal("Received signal: ", s)
+		log.Info("Received signal: ", s)
+		os.Exit(0)
 	}()
 
 	tc := totalConnections{Count: 0}


### PR DESCRIPTION
### Description
Update the log level of the signals `os.Interrupt` and `syscall.SIGTERM` to Info

### CC
@zendesk/guide-ops
