### PR TITLE
Base raingutter on our scratch base image

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -4,6 +4,10 @@ on:
     branches:
     - master
   pull_request:
+
+env:
+  AWS_PROFILE: ecr-publish
+
 jobs:
   main:
     name: go-lang
@@ -25,5 +29,5 @@ jobs:
         git config --global url."https://${{ secrets.ORG_GITHUB_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
         cd ${{ github.workspace }}/gopath/src/github.com/zendesk/${{ github.repository }}
         go test ./raingutter -v
-        docker run --rm -i hadolint/hadolint < Dockerfile
+        docker run --rm -i gcr.io/docker-images-180022/dockerhub-mirror/hadolint/hadolint < Dockerfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -mod=vendor -ldflags "-X main.version=${version}" -o /raingutter raingutter/raingutter.go raingutter/socket_stats.go raingutter/prometheus.go
 
-FROM scratch
+FROM 713408432298.dkr.ecr.us-west-2.amazonaws.com/base/zendesk/docker-images-base/scratch:master
 
 COPY --from=builder /raingutter /
 COPY --from=builder /etc/passwd /etc/passwd


### PR DESCRIPTION
### Description

For compliance reasons we should use the purposely built scratch image
instead of dockerhub scratch.

### CC
@zendesk/guide-ops
