### PR TITLE
name the scratch layer for allowing substitution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -mod=vendor -ldflags "-X main.version=${version}" -o /raingutter raingutter/raingutter.go raingutter/socket_stats.go raingutter/prometheus.go
 
-FROM scratch
+FROM scratch as scratch-base
 
 COPY --from=builder /raingutter /
 COPY --from=builder /etc/passwd /etc/passwd


### PR DESCRIPTION
### Description

Internally we need a different layer than scratch for compliance reasons.

It looks like `scratch` is not overridable, but by giving a different
name it is supported to inject a different build context via buildkit.

### CC
@zendesk/guide-ops
