### PR TITLE
Added dockerfile syntax for buildkit build contexts usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.4
+
 FROM golang:1.19.2-alpine3.16 as builder
 
 RUN addgroup -g 1000 -S raingutter && adduser -u 1000 -S raingutter -G raingutter


### PR DESCRIPTION
### Description

To support build context substitution.

### CC
@zendesk/guide-ops
