### PR TITLE
introduce scratch-base as a separate stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
+FROM scratch as scratch-base
+
 FROM golang:1.19.2-alpine3.16 as builder
 
 RUN addgroup -g 1000 -S raingutter && adduser -u 1000 -S raingutter -G raingutter
@@ -11,7 +13,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -mod=vendor -ldflags "-X main.version=${version}" -o /raingutter raingutter/raingutter.go raingutter/socket_stats.go raingutter/prometheus.go
 
-FROM scratch as scratch-base
+FROM scratch-base
 
 COPY --from=builder /raingutter /
 COPY --from=builder /etc/passwd /etc/passwd


### PR DESCRIPTION
### Description

We're overriding `scratch-base` which is the result image, and we want
to only override the scratch layer, so we introduce it as a isolated
named target, which we can replace the context of instead.

### CC
@zendesk/guide-ops
