### PR TITLE
Upgrade to go 1.22

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,7 +18,7 @@ jobs:
         path: ${{ github.workspace }}/gopath/src/github.com/zendesk/${{ github.repository }}
     - uses: zendesk/setup-go@v2
       with:
-        go-version: 1.17.x
+        go-version: 1.22
     - name: go test
       run: |
         unset GOPROXY
@@ -26,4 +26,3 @@ jobs:
         cd ${{ github.workspace }}/gopath/src/github.com/zendesk/${{ github.repository }}
         go test ./raingutter -v
         docker run --rm -i hadolint/hadolint < Dockerfile
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM scratch as scratch-base
 
-FROM golang:1.20-alpine as builder
+FROM golang:1.22-alpine as builder
 
 RUN addgroup -g 1000 -S raingutter && adduser -u 1000 -S raingutter -G raingutter
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zendesk/raingutter
 
-go 1.20
+go 1.22
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/misc/raindrops/Dockerfile
+++ b/misc/raindrops/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine as builder
+FROM golang:1.22-alpine as builder
 
 LABEL maintainer "GUIDEOPS <guideops@zendesk.com>"
 


### PR DESCRIPTION
### Description
Upgrade to go 1.22 to address [CVE-2023-45288](https://app.wiz.io/explorer/vulnerability-findings#%7E%28entity%7E%28%7E%271fa9ac16-d321-5ac8-a2ca-d2a8f6854de1*2cSECURITY_TOOL_FINDING%29%29)

### CC
@zendesk/guide-ops
